### PR TITLE
Loading defaults permissions_sets to be used for assignments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AWS SSO Terraform module
-![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/avlcloudtechnologies/terraform-aws-sso)
+![GitHub tag (latest by date)](https://img.shields.io/github/v/tag/axel-springer-kugawana/terraform-aws-sso)
 
 This module handles creation of AWS SSO permission sets and assignment to AWS SSO entities and AWS Accounts.
 
@@ -11,7 +11,7 @@ Before this module can be used, please ensure that the following pre-requisites 
 - Ensure that Terraform is using a role with permissions required for AWS SSO management. [Documentation](https://docs.aws.amazon.com/singlesignon/latest/userguide/iam-auth-access-using-id-policies.html#requiredpermissionsconsole).
 
 ## Usage
-More complex examples can be found in the [examples](https://github.com/avlcloudtechnologies/terraform-aws-sso/tree/master/examples) directory. Simple use case:
+More complex examples can be found in the [examples](https://github.com/axel-springer-kugawana/terraform-aws-sso/tree/master/examples) directory. Simple use case:
 
 
 ```hcl

--- a/default_permissions_sets.tf
+++ b/default_permissions_sets.tf
@@ -1,0 +1,17 @@
+locals {
+  default_permissions_sets_names = toset([
+    "AWSPowerUserAccess",
+    "AWSReadOnlyAccess",
+    "AWSAdministratorAccess",
+    "AWSServiceCatalogAdminFullAccess",
+    "AWSOrganizationsFullAccess",
+    "AWSServiceCatalogEndUserAccess"
+  ])
+}
+
+data "aws_ssoadmin_permission_set" "defaults" {
+  for_each = local.default_permissions_sets_names
+
+  instance_arn = local.ssoadmin_instance_arn
+  name = each.key
+}

--- a/locals.tf
+++ b/locals.tf
@@ -10,12 +10,18 @@ locals {
       } if can(ps_attrs.managed_policies)
     ]
   ])
+
+  all_available_permission_sets = merge(
+    data.aws_ssoadmin_permission_set.defaults,
+    aws_ssoadmin_permission_set.this
+  )
+
   account_assignments = flatten([
     for assignment in var.account_assignments : [
       for account_id in assignment.account_ids : {
         principal_name = assignment.principal_name
         principal_type = assignment.principal_type
-        permission_set = aws_ssoadmin_permission_set.this[assignment.permission_set]
+        permission_set = local.all_available_permission_sets[assignment.permission_set]
         account_id     = account_id
       }
     ]


### PR DESCRIPTION
## Description
Introducing default permissions sets provided by AWS so we can use them for assignments in the same way we can use the ones we build in the module itself

## Breaking Changes
None

## Testing
tested in the sso-management stack in aws-platform locally