### PR TITLE
Adding boundary_customer setup

### DIFF
--- a/sso_resources.tf
+++ b/sso_resources.tf
@@ -10,6 +10,19 @@ resource "aws_ssoadmin_permission_set" "this" {
   tags             = lookup(each.value, "tags", {})
 }
 
+resource "aws_ssoadmin_permissions_boundary_attachment" "this" {
+  for_each = {for key,permission_set in var.permission_sets: key => permission_set if permission_set.boundary_customer != null}
+
+  instance_arn = local.ssoadmin_instance_arn
+  permission_set_arn = aws_ssoadmin_permission_set.this[each.key].arn
+  permissions_boundary {
+    customer_managed_policy_reference {
+      name = each.value.boundary_customer
+      path = "/"
+    }
+  }
+}
+
 resource "aws_ssoadmin_permission_set_inline_policy" "this" {
   for_each = { for ps_name, ps_attrs in var.permission_sets : ps_name => ps_attrs if can(ps_attrs.inline_policy) && ps_attrs.inline_policy != null }
 

--- a/sso_resources.tf
+++ b/sso_resources.tf
@@ -18,7 +18,7 @@ resource "aws_ssoadmin_permissions_boundary_attachment" "this" {
   permissions_boundary {
     customer_managed_policy_reference {
       name = each.value.boundary_customer
-      path = "/"
+      path = "/boundaries/"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -12,6 +12,7 @@ variable "permission_sets" {
         session_duration=optional(string),
         tags=optional(map(string)),
         inline_policy=optional(string)
+        boundary_customer=optional(string)
       }
     )
   )


### PR DESCRIPTION
Adding customer_managed boundary optional for permission sets
Will be needed to deploy finops permission set with a custom boundary for https://avivgroup.atlassian.net/browse/AAPSC-1498 deployment with https://github.com/axel-springer-kugawana/aviv-foundation-aws-platform/pull/89