### PR TITLE
fix: Remove experimental features

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,3 @@
-terraform {
-  experiments = [module_variable_optional_attrs]
-}
-
 variable "permission_sets" {
   description = "Map of maps containing Permission Set names as keys. See permission_sets description in README for information about map values."
   type        = map(


### PR DESCRIPTION
## Description
Latest terraform versions do not support experimental features. At the same moment it is not experimental anymore.

Fixes this error:
│ Error: Module uses experimental features
│
│   on .terraform/modules/sso/variables.tf line 2, in terraform:
│    2:   experiments = [module_variable_optional_attrs]
│
│ Experimental features are intended only for gathering early feedback on new language designs, and so are available only in alpha releases of Terraform.

## Breaking Changes
* Any breaking changes?
* No

## Testing
* How was this tested?
* By using Terraform v1.8.5